### PR TITLE
Fetching expired tokens when using a valid service token is now allowed

### DIFF
--- a/oslo_templates/files/queens/keystonemiddleware/_auth_token.conf
+++ b/oslo_templates/files/queens/keystonemiddleware/_auth_token.conf
@@ -197,12 +197,13 @@ memcache_secret_key = {{ _data.cache.security.secret_key }}
 # For backwards compatibility reasons this currently only affects the
 # allow_expired check. (list value)
 #service_token_roles = service
+service_token_roles = admin
 
 # For backwards compatibility reasons we must let valid service tokens pass
 # that don't pass the service_token_roles check as valid. Setting this true
 # will become the default in a future release and should be enabled if
 # possible. (boolean value)
-#service_token_roles_required = false
+service_token_roles_required = true
 
 # Authentication type to load (string value)
 # Deprecated group/name - [keystone_authtoken]/auth_plugin


### PR DESCRIPTION
AuthToken middleware will now allow fetching an expired token when a valid service token is present. 
This will help with long running operations that must continue between services longer than the original expiry of the token. Starting O release is necessary set that option in configuration files of Openstack services to true. Option 'service_token_roles' has been set to 'admin' due to default role of service's users in internal project 'service' is admin. We have tested the settings in Queens deployment.
Better explanation is here: https://docs.openstack.org/releasenotes/keystonemiddleware/ocata.html